### PR TITLE
Support for custom UIViewController

### DIFF
--- a/CJPAdController/CJPAdController.m
+++ b/CJPAdController/CJPAdController.m
@@ -453,7 +453,9 @@ static NSString * const CJPAdsPurchasedKey = @"adRemovalPurchased";
             CJPLog(@"AdView exists and ad is being shown.");
             
             if(_adPosition==CJPAdPositionBottom){
-                contentFrame.size.height -= bannerFrame.size.height;
+                if (_isTabBar || _isNavController) {
+                    contentFrame.size.height -= bannerFrame.size.height;
+                }
                 bannerFrame.origin.y = contentFrame.size.height;
             }
             else if(_adPosition==CJPAdPositionTop){


### PR DESCRIPTION
Hi, your class to run both iAd and AdMob ads works great but I ran into a couple of issues while integrating it in one of my games.

The game uses cocos2d-x and the view controller is neither a UINavigationController or a UITabBarController but a custom UIViewController so I needed to add that possibility to currentViewController.

Additionally the view always uses the whole screen and, in this case, the class should not resize the content frame to account for the banners.
